### PR TITLE
Lesson 7 submittal

### DIFF
--- a/students/Dennis_Coffey/lesson07/html_render.py
+++ b/students/Dennis_Coffey/lesson07/html_render.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Nov 29 21:13:15 2018
+
+@author: dennis
+"""
+
+"""HTML renderer for Lesson 07"""
+
+class Element():
+    tag = '' # Element type
+    indent = 0 # Indent of tag
+    inline = False # Defines whether content is to be displayed on same line
+    empty = False  # Defines whether tag is an empty tag
+    def __init__(self, content=None, **kwargs):
+        self.content_list = []
+        self.kwargs = kwargs
+        if content:
+            self.content_list.append(content)
+        
+    def append(self, content):
+        self.content_list.append(content)
+        
+    def starttag(self, tag):
+        if tag:
+            tag = ' ' * self.indent + '<' + tag
+            if self.kwargs:
+                attribute = ''
+                for k in self.kwargs:
+                    attribute += ' ' + k + '=\"' + self.kwargs[k] + '\"'
+                tag += attribute
+            tag += '>'
+        return tag
+        
+    def endtag(self, tag):
+        if tag:
+            tag = ' ' * self.indent + '</' + tag + '>'
+        return tag
+        
+    def render(self, output_file, indent=0):
+        # Render opening tag
+        output_file.write(self.starttag(self.tag))
+        if not self.inline and not self.empty:
+            output_file.write('\n')
+        
+        # Render content
+        if self.content_list:
+            for item in self.content_list:
+                if type(item) == str:
+                    output_file.write(item)
+                else:
+                    item.render(output_file, indent + 4)
+                if not self.inline:
+                    output_file.write('\n')
+                
+        # Render closing tag
+        if not self.empty:
+            output_file.write(self.endtag(self.tag))
+        
+class Html(Element):
+    tag = 'html'
+    indent = 0
+    
+#    def render(self, output_file, indent=0):
+#        output_file.write('<!DOCTYPE html>\n')
+#        super().render(output_file, indent)        
+
+    
+class Body(Element):
+    tag = 'body'
+    indent = 0
+    
+class P(Element):
+    tag = 'p'
+    indent = 0
+    
+class Head(Element):
+    tag = 'head'
+    indent = 0
+    
+class Title(Element):
+    tag = 'title'
+    indent = 0
+    inline = True
+    
+class SelfClosingTag(Element):
+    
+    def __init__(self, content=None, **kwargs):
+        self.kwargs = kwargs
+        if content:
+            raise TypeError('Content is not allowed for Self Closing Tag elements')
+
+    def render(self, output_file, indent=0):
+        # Render opening tag
+        output_file.write('<' + self.tag)
+        
+        # Render attribute
+        if self.kwargs:
+            attribute = ''
+            for k in self.kwargs:
+                attribute += ' ' + k + '=\"' + self.kwargs[k] + '\"'
+            output_file.write(attribute)
+                
+        # Render closing tag
+        output_file.write(' />')
+    
+class Hr(SelfClosingTag):
+    tag = 'hr'
+    indent = 0
+    empty = True
+    
+class Br(SelfClosingTag):
+    tag = 'br'
+    indent = 0
+    
+class Meta(SelfClosingTag):
+    tag = 'meta'
+    indent = 0
+
+class A(Element):
+    tag = 'a'
+    indent = 0
+    inline = True
+    def __init__(self, link, content, **kwargs):
+        self.content_list = []
+        self.kwargs = kwargs
+        self.kwargs['href'] = link
+        if content:
+            self.content_list.append(content)
+
+class H(Element):
+    tag = 'h'
+    indent = 0
+    inline = True
+    def __init__(self, level, content, **kwargs):
+        self.content_list = []
+        self.kwargs = kwargs
+        self.tag = self.tag + str(level)
+        if content:
+            self.content_list.append(content)
+
+class Ul(Element):
+    tag = 'ul'
+    indent = 0
+    
+class Li(Element):
+    tag = 'li'
+    indent = 0
+    
+    

--- a/students/Dennis_Coffey/lesson07/html_render.py
+++ b/students/Dennis_Coffey/lesson07/html_render.py
@@ -7,9 +7,10 @@ Created on Thu Nov 29 21:13:15 2018
 
 """HTML renderer for Lesson 07"""
 
+# Base element class
 class Element():
     tag = '' # Element type
-    indent = 0 # Indent of tag
+    indent_size = ' '* 4 # Indent of tag
     inline = False # Defines whether content is to be displayed on same line
     empty = False  # Defines whether tag is an empty tag
     def __init__(self, content=None, **kwargs):
@@ -18,12 +19,14 @@ class Element():
         if content:
             self.content_list.append(content)
         
+    # Append content
     def append(self, content):
         self.content_list.append(content)
         
-    def starttag(self, tag):
+    # Start tag for element
+    def starttag(self, tag, indent):
         if tag:
-            tag = ' ' * self.indent + '<' + tag
+            tag = self.indent_size * indent + '<' + tag
             if self.kwargs:
                 attribute = ''
                 for k in self.kwargs:
@@ -32,14 +35,18 @@ class Element():
             tag += '>'
         return tag
         
-    def endtag(self, tag):
-        if tag:
-            tag = ' ' * self.indent + '</' + tag + '>'
+    # End tag for element
+    def endtag(self, tag, indent):
+        if tag and not self.inline:
+            tag = self.indent_size * indent + '</' + tag + '>'
+        elif tag:
+            tag = '</' + tag + '>'
         return tag
         
+    # Generate start tag, content and closing tag
     def render(self, output_file, indent=0):
         # Render opening tag
-        output_file.write(self.starttag(self.tag))
+        output_file.write(self.starttag(self.tag, indent))
         if not self.inline and not self.empty:
             output_file.write('\n')
         
@@ -47,42 +54,45 @@ class Element():
         if self.content_list:
             for item in self.content_list:
                 if type(item) == str:
-                    output_file.write(item)
+                    if self.inline:
+                        output_file.write(item)
+                    else:
+                        output_file.write(self.indent_size * indent + item)
                 else:
-                    item.render(output_file, indent + 4)
+                    item.render(output_file, indent + 1)
                 if not self.inline:
                     output_file.write('\n')
                 
         # Render closing tag
         if not self.empty:
-            output_file.write(self.endtag(self.tag))
+            output_file.write(self.endtag(self.tag, indent))
         
+# html tag
 class Html(Element):
     tag = 'html'
-    indent = 0
     
-#    def render(self, output_file, indent=0):
-#        output_file.write('<!DOCTYPE html>\n')
-#        super().render(output_file, indent)        
+    def render(self, output_file, indent=0):
+        output_file.write('<!DOCTYPE html>\n')
+        super().render(output_file, indent)        
 
-    
+# body tag
 class Body(Element):
     tag = 'body'
-    indent = 0
     
+# paragraph tag
 class P(Element):
     tag = 'p'
-    indent = 0
     
+# head tag
 class Head(Element):
     tag = 'head'
-    indent = 0
     
+# title tag
 class Title(Element):
     tag = 'title'
-    indent = 0
     inline = True
     
+# tag with no content
 class SelfClosingTag(Element):
     
     def __init__(self, content=None, **kwargs):
@@ -92,7 +102,7 @@ class SelfClosingTag(Element):
 
     def render(self, output_file, indent=0):
         # Render opening tag
-        output_file.write('<' + self.tag)
+        output_file.write(self.indent_size * indent + '<' + self.tag)
         
         # Render attribute
         if self.kwargs:
@@ -104,22 +114,22 @@ class SelfClosingTag(Element):
         # Render closing tag
         output_file.write(' />')
     
+# horizontal ruler tag
 class Hr(SelfClosingTag):
     tag = 'hr'
-    indent = 0
     empty = True
     
+# br/ tag
 class Br(SelfClosingTag):
     tag = 'br'
-    indent = 0
     
+# meta tag
 class Meta(SelfClosingTag):
     tag = 'meta'
-    indent = 0
 
+# a tag
 class A(Element):
     tag = 'a'
-    indent = 0
     inline = True
     def __init__(self, link, content, **kwargs):
         self.content_list = []
@@ -128,9 +138,9 @@ class A(Element):
         if content:
             self.content_list.append(content)
 
+# header tag
 class H(Element):
     tag = 'h'
-    indent = 0
     inline = True
     def __init__(self, level, content, **kwargs):
         self.content_list = []
@@ -139,12 +149,11 @@ class H(Element):
         if content:
             self.content_list.append(content)
 
+# unordered list tag
 class Ul(Element):
     tag = 'ul'
-    indent = 0
     
+# list tag
 class Li(Element):
     tag = 'li'
-    indent = 0
-    
-    
+       

--- a/students/Dennis_Coffey/lesson07/html_render.py
+++ b/students/Dennis_Coffey/lesson07/html_render.py
@@ -11,6 +11,7 @@ Created on Thu Nov 29 21:13:15 2018
 class Element():
     tag = '' # Element type
     indent_size = ' '* 4 # Indent of tag
+#    indent_size = ''* 4 # Use this cause no indent for Steps 1-8
     inline = False # Defines whether content is to be displayed on same line
     empty = False  # Defines whether tag is an empty tag
     def __init__(self, content=None, **kwargs):
@@ -71,6 +72,9 @@ class Element():
 class Html(Element):
     tag = 'html'
     
+    # Overwrite Element render method to add <!DOCTYPE html> before html tag
+    # Comment out next 3 lines of code to not add <!DOCTYPE html> so that Steps 1-8
+    # assert statements will pass
     def render(self, output_file, indent=0):
         output_file.write('<!DOCTYPE html>\n')
         super().render(output_file, indent)        

--- a/students/Dennis_Coffey/lesson07/test_html_output2.htm
+++ b/students/Dennis_Coffey/lesson07/test_html_output2.htm
@@ -1,0 +1,10 @@
+<html>
+<body>
+<p>
+Here is a paragraph of text -- there could be more of them, but this is enough  to show that we can do some text
+</p>
+<p>
+And here is another piece of text -- you should be able to add any number
+</p>
+</body>
+</html>

--- a/students/Dennis_Coffey/lesson07/test_html_output3.htm
+++ b/students/Dennis_Coffey/lesson07/test_html_output3.htm
@@ -1,0 +1,13 @@
+<html>
+<head>
+<title>PythonClass = Revision 1087:</title>
+</head>
+<body>
+<p>
+Here is a paragraph of text -- there could be more of them, but this is enough  to show that we can do some text
+</p>
+<p>
+And here is another piece of text -- you should be able to add any number
+</p>
+</body>
+</html>

--- a/students/Dennis_Coffey/lesson07/test_html_output4.htm
+++ b/students/Dennis_Coffey/lesson07/test_html_output4.htm
@@ -1,0 +1,10 @@
+<html>
+<head>
+<title>PythonClass = Revision 1087:</title>
+</head>
+<body>
+<p style="text-align: center; font-style: oblique;">
+Here is a paragraph of text -- there could be more of them, but this is enough  to show that we can do some text
+</p>
+</body>
+</html>

--- a/students/Dennis_Coffey/lesson07/test_html_output5.htm
+++ b/students/Dennis_Coffey/lesson07/test_html_output5.htm
@@ -1,0 +1,11 @@
+<html>
+<head>
+<title>PythonClass = Revision 1087:</title>
+</head>
+<body>
+<p style="text-align: center; font-style: oblique;">
+Here is a paragraph of text -- there could be more of them, but this is enough  to show that we can do some text
+</p>
+<hr />
+</body>
+</html>

--- a/students/Dennis_Coffey/lesson07/test_html_output6.htm
+++ b/students/Dennis_Coffey/lesson07/test_html_output6.htm
@@ -1,0 +1,14 @@
+<html>
+<head>
+<title>PythonClass = Revision 1087:</title>
+</head>
+<body>
+<p style="text-align: center; font-style: oblique;">
+Here is a paragraph of text -- there could be more of them, but this is enough  to show that we can do some text
+</p>
+<hr />
+And this is a 
+<a href="http://google.com">link</a>
+to google
+</body>
+</html>

--- a/students/Dennis_Coffey/lesson07/test_html_output7.htm
+++ b/students/Dennis_Coffey/lesson07/test_html_output7.htm
@@ -1,0 +1,25 @@
+<html>
+<head>
+<title>PythonClass = Revision 1087:</title>
+</head>
+<body>
+<h2>PythonClass - Class 6 example</h2>
+<p style="text-align: center; font-style: oblique;">
+Here is a paragraph of text -- there could be more of them, but this is enough  to show that we can do some text
+</p>
+<hr />
+<ul id="TheList" style="line-height:200%">
+<li>
+The first item in a list
+</li>
+<li style="color: red">
+This is the second item
+</li>
+<li>
+And this is a 
+<a href="http://google.com">link</a>
+to google
+</li>
+</ul>
+</body>
+</html>

--- a/students/Dennis_Coffey/lesson07/test_html_output8.htm
+++ b/students/Dennis_Coffey/lesson07/test_html_output8.htm
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<title>PythonClass = Revision 1087:</title>
+</head>
+<body>
+<h2>PythonClass - Class 6 example</h2>
+<p style="text-align: center; font-style: oblique;">
+Here is a paragraph of text -- there could be more of them, but this is enough  to show that we can do some text
+</p>
+<hr />
+<ul id="TheList" style="line-height:200%">
+<li>
+The first item in a list
+</li>
+<li style="color: red">
+This is the second item
+</li>
+<li>
+And this is a
+<a href="http://google.com">link</a>
+to google
+</li>
+</ul>
+</body>
+</html>

--- a/students/Dennis_Coffey/lesson07/test_html_render.py
+++ b/students/Dennis_Coffey/lesson07/test_html_render.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+Test suite for HTML render lesson 07 exercise
+"""
+
+import pytest
+
+from io import StringIO
+
+# importing the html_rendering code with a short name for easy typing.
+import html_render as hr
+
+from run_html_render import *
+
+f = StringIO()
+page.render(f)
+
+
+# Test for Step 1 of run_html_render
+#def test_Element():
+#    assert f.getvalue() == 'Here is a paragraph of text -- there could be more of them, but this is enough  to show that we can do some textAnd here is another piece of text -- you should be able to add any number'
+
+# Funtion to compare desired vs generated result for each step
+def compare_files(desired_file, generated_file):
+    desired_file = open(desired_file)
+    desired_result = desired_file.read()
+    generated_file = open(generated_file)
+    generated_result = generated_file.read()
+    assert desired_result == generated_result
+    desired_file.close()
+    generated_file.close()
+
+# Test for Step 2 of run_html_render
+def test_step2():
+    compare_files('test_html_output2.htm', 'test_html_output2.html')        
+    
+# Test for Step 3 of run_html_render
+def test_step3():
+    compare_files('test_html_output3.htm', 'test_html_output3.html')        
+
+# Test for Step 4 of run_html_render
+def test_step4():
+    compare_files('test_html_output4.htm', 'test_html_output4.html')        
+
+# Test for Step 5 of run_html_render
+def test_step5():
+    compare_files('test_html_output5.htm', 'test_html_output5.html')        
+
+
+# Test for Step 6 of run_html_render
+def test_step6():
+    compare_files('test_html_output6.htm', 'test_html_output6.html')        
+
+# Test for Step 7 of run_html_render
+def test_step7():
+    compare_files('test_html_output7.htm', 'test_html_output7.html')        
+
+# Test for Step 8 of run_html_render
+#def test_step8():
+#    compare_files('test_html_output8.htm', 'test_html_output8.html')        

--- a/students/Dennis_Coffey/lesson07/test_html_render.py
+++ b/students/Dennis_Coffey/lesson07/test_html_render.py
@@ -17,8 +17,8 @@ page.render(f)
 
 
 # Test for Step 1 of run_html_render
-#def test_Element():
-#    assert f.getvalue() == 'Here is a paragraph of text -- there could be more of them, but this is enough  to show that we can do some textAnd here is another piece of text -- you should be able to add any number'
+def test_Element():
+    assert f.getvalue() == 'Here is a paragraph of text -- there could be more of them, but this is enough  to show that we can do some textAnd here is another piece of text -- you should be able to add any number'
 
 # Funtion to compare desired vs generated result for each step
 def compare_files(desired_file, generated_file):
@@ -56,5 +56,5 @@ def test_step7():
     compare_files('test_html_output7.htm', 'test_html_output7.html')        
 
 # Test for Step 8 of run_html_render
-#def test_step8():
-#    compare_files('test_html_output8.htm', 'test_html_output8.html')        
+def test_step8():
+    compare_files('test_html_output8.htm', 'test_html_output8.html')        


### PR DESCRIPTION
Submitting html_render.py and test_html_render.py.  

The assert statements in test_html_render.py will all fail with the current version of html_render.py.  This is because the .htm files used for comparison don't include indentation which was added to html_render at the end.  The test_Element() assert only worked for Step 1.  Step 8 assert can be made to work by getting rid of indent by commenting out row 13 and uncommenting row 14.  Step 2-7 asserts can then be made to work by commenting out rows 78-80 so that the <!DOCTYPE html> tag does not display.  